### PR TITLE
SDP-12 feat: add RankingScreen

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -152,6 +152,11 @@ public final class Core {
 					menu = frame.setScreen(currentScreen);
 					break;
 
+				case RANKING:
+					currentScreen = new RankingScreen(width, height, FPS);
+					menu = frame.setScreen(currentScreen);
+					break;
+
                 default:
                     break;
             }

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -1979,4 +1979,79 @@ public final class DrawManager {
 
 		}
 	}
+
+	/**
+	 * Draws the ranking screen.
+	 *
+	 * @param screen
+	 *               screen to draw on.
+	 * @param rankings
+	 *                 List of ranking entries.
+	 * @param scrollOffset
+	 *                     Current scroll offset for the ranking list.
+	 */
+
+	public void drawRankingScreen(final Screen screen, List<RankingEntry> rankings, final int scrollOffset){
+
+		String rankingTitle = "Ranking";
+		String rankHeader = "Rank";
+		String nameHeader = "UserName";
+		String scoreHeader = "HighScore";
+
+		int titleY = screen.getHeight() / 12;
+		int headerY = screen.getHeight() / 8;
+		int rowStartY = headerY + screen.getHeight() / 20;
+		int rowHeight = screen.getHeight() / 20;
+		int rankX = screen.getWidth() / 8;
+		int nameX = screen.getWidth() / 3;
+		int scoreX = screen.getWidth() * 3 / 4;
+
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredBigString(screen, rankingTitle, titleY);
+
+		backBufferGraphics.setColor(Color.LIGHT_GRAY);
+		backBufferGraphics.setFont(fontSmall);
+		backBufferGraphics.drawString(rankHeader, rankX, headerY);
+		backBufferGraphics.drawString(nameHeader, nameX, headerY);
+		backBufferGraphics.drawString(scoreHeader, scoreX, headerY);
+
+		for (int i = scrollOffset; i < Math.min(rankings.size(), scrollOffset + screen.getHeight() / rowHeight); i++) {
+			int y = rowStartY + (i - scrollOffset) * rowHeight;
+
+			// Stop drawing if it exceeds the screen height
+			if (y > screen.getHeight() - 50) break;
+
+			// Draw rank, username, and highScore
+			String rankText = String.valueOf(i + 1); // Rank as a string
+			String userName = rankings.get(i).getUserId(); // UserName
+			String highScore = String.valueOf(rankings.get(i).getHighScore()); // HighScore
+
+			// Render text at appropriate positions
+			backBufferGraphics.setColor(Color.WHITE);
+			backBufferGraphics.drawString(rankText, rankX, y);
+			backBufferGraphics.drawString(userName, nameX, y);
+			backBufferGraphics.drawString(highScore, scoreX, y);
+		}
+
+		// Scroll indicators
+		if (scrollOffset > 0) {
+			backBufferGraphics.setColor(Color.GRAY);
+			backBufferGraphics.drawString("↑ Scroll Up", screen.getWidth() / 2 - 50, 30);
+		}
+		if (scrollOffset + (screen.getHeight() / rowHeight) < rankings.size()) {
+			backBufferGraphics.setColor(Color.GRAY);
+			backBufferGraphics.drawString("↓ Scroll Down", screen.getWidth() / 2 - 50, screen.getHeight() - 30);
+		}
+
+	}
+
+	public void drawLoadingScreen(final Screen screen){
+		backBufferGraphics.setColor(Color.YELLOW);
+		backBufferGraphics.drawString("Loading Rankings...", screen.getWidth() / 2 - 80, screen.getHeight() / 2);
+	}
+
+	public void drawErrorMessage(final Screen screen, final String message) {
+		backBufferGraphics.setColor(Color.RED);
+		backBufferGraphics.drawString(message, screen.getWidth() / 2 - 80, screen.getHeight() / 2);
+	}
 }

--- a/src/engine/Menu.java
+++ b/src/engine/Menu.java
@@ -4,6 +4,7 @@ public enum Menu {
     GAME_SETTING,
     SHOP,
     ACHIEVEMENT,
+    RANKING,
     SETTING,
     EXIT,
     MAIN,
@@ -12,8 +13,8 @@ public enum Menu {
     CREDIT,
     SCORE;
 
-    static final Menu[] TITLE_MENU = {GAME_SETTING, SHOP, ACHIEVEMENT, SETTING, EXIT};
-    private static final int TILE_MENU_COUNT = 5;
+    static final Menu[] TITLE_MENU = {GAME_SETTING, SHOP, ACHIEVEMENT, RANKING, SETTING, EXIT};
+    private static final int TILE_MENU_COUNT = 6;
 
     public Menu getNext() {
         return TITLE_MENU[(this.ordinal() + 1) % TILE_MENU_COUNT];

--- a/src/entity/RankingEntry.java
+++ b/src/entity/RankingEntry.java
@@ -1,0 +1,19 @@
+package entity;
+
+public class RankingEntry {
+    private final String userId;
+    private final int highScore;
+
+    public RankingEntry(String userId, int highScore){
+        this.userId = userId;
+        this.highScore = highScore;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public int getHighScore() {
+        return highScore;
+    }
+}

--- a/src/entity/RankingService.java
+++ b/src/entity/RankingService.java
@@ -1,0 +1,53 @@
+package entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankingService {
+
+    /**
+     * Fatches rankings from the server.
+     *
+     * @return List of RankingEntry objects.
+     * @throws Exception If the server communication fails.
+     */
+    public List<RankingEntry> fetchRankingsFromServer() throws Exception{
+        //Replace this with actual HTTP request Logic
+
+        // Simulating server response
+        List<RankingEntry> rankings = new ArrayList<>();
+        rankings.add(new RankingEntry("ServerUser1", 3000));
+        rankings.add(new RankingEntry("ServerUser2", 2950));
+        rankings.add(new RankingEntry("ServerUser3", 2900));
+        rankings.add(new RankingEntry("ServerUser4", 2850));
+        rankings.add(new RankingEntry("ServerUser5", 2800));
+        rankings.add(new RankingEntry("ServerUser6", 2750));
+        rankings.add(new RankingEntry("ServerUser7", 2700));
+        rankings.add(new RankingEntry("ServerUser8", 2650));
+        rankings.add(new RankingEntry("ServerUser9", 2600));
+        rankings.add(new RankingEntry("ServerUser10", 2550));
+        rankings.add(new RankingEntry("ServerUser11", 2500));
+        rankings.add(new RankingEntry("ServerUser12", 2450));
+        rankings.add(new RankingEntry("ServerUser13", 2400));
+        rankings.add(new RankingEntry("ServerUser14", 2350));
+        rankings.add(new RankingEntry("ServerUser15", 2300));
+        rankings.add(new RankingEntry("ServerUser16", 2250));
+        rankings.add(new RankingEntry("ServerUser17", 2200));
+        rankings.add(new RankingEntry("ServerUser18", 2150));
+        rankings.add(new RankingEntry("ServerUser19", 2100));
+        rankings.add(new RankingEntry("ServerUser20", 2050));
+        rankings.add(new RankingEntry("ServerUser21", 2000));
+        rankings.add(new RankingEntry("ServerUser22", 1950));
+        rankings.add(new RankingEntry("ServerUser23", 1900));
+        rankings.add(new RankingEntry("ServerUser24", 1850));
+        rankings.add(new RankingEntry("ServerUser25", 1800));
+        rankings.add(new RankingEntry("ServerUser26", 1750));
+        rankings.add(new RankingEntry("ServerUser27", 1700));
+        rankings.add(new RankingEntry("ServerUser28", 1650));
+        rankings.add(new RankingEntry("ServerUser29", 1600));
+        rankings.add(new RankingEntry("ServerUser30", 1550));
+
+
+        return rankings;
+    }
+}

--- a/src/screen/RankingScreen.java
+++ b/src/screen/RankingScreen.java
@@ -1,0 +1,104 @@
+package screen;
+
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.List;
+import java.util.logging.Logger;
+
+import engine.*;
+import entity.RankingService;
+import entity.RankingEntry;
+
+public class RankingScreen extends Screen{
+
+    /** List of ranking entries fetched from the server.*/
+    private List<RankingEntry> rankings;
+    private final RankingService rankingService = new RankingService();
+    /** Singleton instance of SoundManager*/
+    private final SoundManager soundManager = SoundManager.getInstance();
+
+    private boolean isLoading = true;
+    private int scrollOffset = 0;
+    private final int rowsPerPage;
+    private static final int COOLDOWN_TIME = 200;
+    private static final Logger logger = Logger.getLogger(RankingScreen.class.getName());
+
+    /**
+     * Constructor, establishes the properties of the screen.
+     *
+     * @param width Screen width.
+     * @param height Screen height.
+     * @param fps Frames per second, frame rate at which the game is run.
+     */
+
+    public RankingScreen(final int width, final int height, final int fps) {
+        super(width, height, fps);
+        rowsPerPage = 16;
+        this.inputDelay = Core.getCooldown(COOLDOWN_TIME);
+        loadRankings();
+    }
+
+    private void loadRankings(){
+        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            executor.submit(() -> {
+                try {
+                    rankings = rankingService.fetchRankingsFromServer();
+                } catch (Exception e) {
+                    logger.warning("Failed to load rankings: " + e.getMessage());
+                    rankings = List.of(); // Set empty list if loading fails
+                } finally {
+                    isLoading = false; // Mark loading as complete
+                }
+            });
+            executor.shutdown();
+            if (!executor.awaitTermination(60, java.util.concurrent.TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            logger.warning("Executor was interrupted: " + e.getMessage());
+        }
+
+    }
+
+    /**
+     * Updates the elements on screen and checks for events.
+     */
+    @Override
+    protected final void update() {
+        super.update();
+
+        if (inputManager.isKeyDown(KeyEvent.VK_UP) && this.inputDelay.checkFinished()) {
+            scrollOffset = Math.max(scrollOffset - 1, 0);
+            inputDelay.reset();
+            soundManager.playSound(Sound.MENU_MOVE);
+        }
+        if (inputManager.isKeyDown(KeyEvent.VK_DOWN) && this.inputDelay.checkFinished()) {
+            scrollOffset = Math.min(scrollOffset + 1, Math.max(0, rankings.size() - rowsPerPage));
+            inputDelay.reset();
+            soundManager.playSound(Sound.MENU_MOVE);
+        }
+        if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE) && this.inputDelay.checkFinished()) {
+            this.isRunning = false; // Exit the screen
+            soundManager.playSound(Sound.MENU_BACK);
+        }
+
+        draw();
+    }
+
+    private void draw(){
+        drawManager.initDrawing(this);
+
+        if (isLoading) {
+            drawManager.drawLoadingScreen(this);
+        } else if (rankings.isEmpty()) {
+            drawManager.drawErrorMessage(this, "Failed to load rankings.");
+        } else {
+            drawManager.drawRankingScreen(this, rankings, scrollOffset);
+        }
+
+        drawManager.completeDrawing(this);
+    }
+
+}


### PR DESCRIPTION
- Create `RankingScreen` class: Show the ranking screen including rank, user ID, high score. It can scroll down. But `rowPerPage`, number of data that can be viewed at once, couldn't define if and entered it as a constant.
- Create `RankingEntry` class: Serve data model representing individual ranking entries.
- Create `RankingService` class: Fetch ranking data from a server. In the current implementation, it simlates a server response by returning manipulated data.
- Modify `DrawManager`: Add `drawRankingScreen` `drawLoadingScreen` and `drawErrorMessage` methods to handle rendering the respective screens.
- Update `Core` and `Menu`: Add new contants, `Ranking`, to represent the ranking screen in the application flow.